### PR TITLE
update iterator to remove lifetime

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -45,7 +45,7 @@ impl Agate {
         }
 
         let mut txn = self.core.new_transaction(true, true);
-        txn.commit_ts = commit_ts;
+        txn.set_commit_ts(commit_ts);
         WriteBatch {
             txn,
             core: self.core.clone(),
@@ -92,8 +92,8 @@ impl WriteBatch {
         }
 
         let mut new_txn = self.core.new_transaction(true, self.is_managed);
-        new_txn.commit_ts = self.commit_ts;
-        let txn = std::mem::replace(&mut self.txn, new_txn);
+        new_txn.set_commit_ts(self.commit_ts);
+        let mut txn = std::mem::replace(&mut self.txn, new_txn);
         txn.commit()?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod watermark;
 pub use db::{Agate, AgateOptions};
 pub use error::{Error, Result};
 pub use format::{get_ts, key_with_ts};
-pub use iterator::IteratorOptions;
+pub use iterator::{Iterator, IteratorOptions};
 pub use iterator_trait::AgateIterator;
 pub use opt::{ChecksumVerificationMode, Options as TableOptions};
 pub use skiplist::Skiplist;

--- a/src/managed_db.rs
+++ b/src/managed_db.rs
@@ -13,8 +13,8 @@ impl crate::db::Core {
             );
         }
 
-        let mut txn = self.new_transaction(update, true);
-        txn.read_ts = read_ts;
+        let txn = self.new_transaction(update, true);
+        txn.inner.lock().unwrap().read_ts = read_ts;
         txn
     }
 
@@ -47,10 +47,10 @@ impl Transaction {
     ///
     /// This will panic if not used with managed transactions.
     pub fn commit_at(mut self, commit_ts: u64) -> Result<()> {
-        if !self.core.opts.managed_txns {
+        if !self.inner.lock().unwrap().core.opts.managed_txns {
             panic!("Cannot use commit_at when managed_txns is false. Use commit_at instead.");
         }
-        self.commit_ts = commit_ts;
+        self.inner.lock().unwrap().commit_ts = commit_ts;
         self.commit()?;
         Ok(())
     }

--- a/src/ops/transaction_test.rs
+++ b/src/ops/transaction_test.rs
@@ -341,7 +341,7 @@ mod normal_db {
 
             for i in 1..10 {
                 let mut txn = agate.new_transaction(true);
-                txn.read_ts = i; // Read version at i.
+                txn.set_read_ts(i); // Read version at i.
 
                 let item = txn.get(&key).unwrap();
                 let value = item.value();
@@ -506,19 +506,19 @@ mod normal_db {
             check_iterator(it, vec!["c2", "a3"]);
             check_iterator(it5, vec!["b4", "a3"]);
 
-            txn.read_ts = 3;
+            txn.set_read_ts(3);
             let it = txn.new_iterator(&IteratorOptions::default());
             check_iterator(it, vec!["a3", "b3", "c2"]);
             let it = txn.new_iterator(&rev);
             check_iterator(it, vec!["c2", "b3", "a3"]);
 
-            txn.read_ts = 2;
+            txn.set_read_ts(2);
             let it = txn.new_iterator(&IteratorOptions::default());
             check_iterator(it, vec!["a2", "c2"]);
             let it = txn.new_iterator(&rev);
             check_iterator(it, vec!["c2", "a2"]);
 
-            txn.read_ts = 1;
+            txn.set_read_ts(1);
             let it = txn.new_iterator(&IteratorOptions::default());
             check_iterator(it, vec!["c1"]);
             let it = txn.new_iterator(&rev);
@@ -596,7 +596,7 @@ mod normal_db {
             let it = txn.new_iterator(&rev);
             check_iterator(it, vec!["c2", "a3"]);
 
-            txn.read_ts = 5;
+            txn.set_read_ts(5);
             {
                 let mut it = txn.new_iterator(&IteratorOptions::default());
                 it.seek(&ka);
@@ -615,19 +615,19 @@ mod normal_db {
                 assert_bytes_eq!(&it.item().key, &kc);
             }
 
-            txn.read_ts = 3;
+            txn.set_read_ts(3);
             let it = txn.new_iterator(&IteratorOptions::default());
             check_iterator(it, vec!["a3", "b3", "c2"]);
             let it = txn.new_iterator(&rev);
             check_iterator(it, vec!["c2", "b3", "a3"]);
 
-            txn.read_ts = 2;
+            txn.set_read_ts(2);
             let it = txn.new_iterator(&IteratorOptions::default());
             check_iterator(it, vec!["a2", "c2"]);
             let it = txn.new_iterator(&rev);
             check_iterator(it, vec!["c2", "a2"]);
 
-            txn.read_ts = 1;
+            txn.set_read_ts(1);
             let it = txn.new_iterator(&IteratorOptions::default());
             check_iterator(it, vec!["c1"]);
             let it = txn.new_iterator(&rev);
@@ -791,7 +791,7 @@ mod normal_db {
 
             agate
                 .view(|txn| {
-                    txn.read_ts = 2;
+                    txn.set_read_ts(2);
                     let mut it = txn.new_iterator(&IteratorOptions {
                         all_versions: true,
                         ..Default::default()


### PR DESCRIPTION
Since `engine_traits::iterable::Iterator` trait has `Send` bound, we should use `Arc<Mutex<TransactionInner>>` in `agatedb::iterator::Iterator` as a workaround.

Signed-off-by: GanZiheng <ganziheng98@gmail.com>