### PR TITLE
iterator: update all iterators to uniform behavior and implement `prev` and `to_last` to `Iterator`

### DIFF
--- a/skiplist/src/list.rs
+++ b/skiplist/src/list.rs
@@ -438,7 +438,10 @@ impl<T: AsRef<Skiplist<C>>, C: KeyComparator> IterRef<T, C> {
     }
 
     pub fn next(&mut self) {
-        assert!(self.valid());
+        if !self.valid() {
+            return;
+        }
+
         unsafe {
             let cursor_offset = (&*self.cursor).next_offset(0);
             self.cursor = self.list.as_ref().inner.arena.get_mut(cursor_offset);
@@ -446,7 +449,10 @@ impl<T: AsRef<Skiplist<C>>, C: KeyComparator> IterRef<T, C> {
     }
 
     pub fn prev(&mut self) {
-        assert!(self.valid());
+        if !self.valid() {
+            return;
+        }
+
         if self.list.as_ref().allow_concurrent_write {
             unsafe {
                 self.cursor = self.list.as_ref().find_near(self.key(), true, false);

--- a/skiplist/src/list.rs
+++ b/skiplist/src/list.rs
@@ -424,7 +424,7 @@ unsafe impl<T, C> Send for IterRef<T, C> where T: AsRef<Skiplist<C>> {}
 
 impl<T: AsRef<Skiplist<C>>, C: KeyComparator> IterRef<T, C> {
     pub fn valid(&self) -> bool {
-        !self.cursor.is_null()
+        !(self.cursor.is_null() || self.cursor == self.list.as_ref().inner.head.as_ptr())
     }
 
     pub fn key(&self) -> &Bytes {
@@ -438,7 +438,10 @@ impl<T: AsRef<Skiplist<C>>, C: KeyComparator> IterRef<T, C> {
     }
 
     pub fn next(&mut self) {
-        if !self.valid() {
+        if self.cursor.is_null() {
+            return;
+        } else if self.cursor == self.list.as_ref().inner.head.as_ptr() {
+            self.seek_to_first();
             return;
         }
 
@@ -449,23 +452,27 @@ impl<T: AsRef<Skiplist<C>>, C: KeyComparator> IterRef<T, C> {
     }
 
     pub fn prev(&mut self) {
-        if !self.valid() {
+        if self.cursor.is_null() {
+            self.seek_to_last();
+            return;
+        } else if self.cursor == self.list.as_ref().inner.head.as_ptr() {
             return;
         }
 
         if self.list.as_ref().allow_concurrent_write {
             unsafe {
-                self.cursor = self.list.as_ref().find_near(self.key(), true, false);
+                let node = self.list.as_ref().find_near(self.key(), true, false);
+                if node.is_null() {
+                    self.cursor = self.list.as_ref().inner.head.as_ptr();
+                } else {
+                    self.cursor = node
+                }
             }
         } else {
             unsafe {
                 let prev_offset = (*self.cursor).prev.load(Ordering::Acquire);
                 let node = self.list.as_ref().inner.arena.get_mut(prev_offset);
-                if node != self.list.as_ref().inner.head.as_ptr() {
-                    self.cursor = node;
-                } else {
-                    self.cursor = ptr::null();
-                }
+                self.cursor = node;
             }
         }
     }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -619,7 +619,7 @@ mod tests {
 
         check(skl.clone(), false);
 
-        check(skl.clone(), true);
+        check(skl, true);
     }
 
     #[test]

--- a/src/ops/transaction.rs
+++ b/src/ops/transaction.rs
@@ -53,7 +53,7 @@ pub struct Transaction {
 
 pub struct PendingWritesIterator {
     entries: Vec<Entry>,
-    next_idx: i64,
+    next_idx: usize,
     read_ts: u64,
     reversed: bool,
     key: BytesMut,
@@ -486,8 +486,12 @@ impl PendingWritesIterator {
 
 impl AgateIterator for PendingWritesIterator {
     fn next(&mut self) {
-        self.next_idx += 1;
-        self.update_key();
+        if self.next_idx == std::usize::MAX {
+            self.rewind();
+        } else if self.next_idx < self.entries.len() {
+            self.next_idx += 1;
+            self.update_key();
+        }
     }
 
     fn rewind(&mut self) {
@@ -507,7 +511,7 @@ impl AgateIterator for PendingWritesIterator {
             } else {
                 cmp != Greater
             }
-        }) as i64;
+        });
 
         self.update_key();
     }
@@ -530,18 +534,24 @@ impl AgateIterator for PendingWritesIterator {
     }
 
     fn valid(&self) -> bool {
-        self.next_idx >= 0 && self.next_idx < self.entries.len() as i64
+        self.next_idx != std::usize::MAX && self.next_idx < self.entries.len()
     }
 
     fn prev(&mut self) {
-        assert!(self.next_idx >= 0);
-        self.next_idx -= 1;
-        self.update_key();
+        if self.next_idx == std::usize::MAX {
+        } else if self.next_idx > 0 {
+            self.next_idx -= 1;
+            self.update_key();
+        } else {
+            self.next_idx = std::usize::MAX;
+        }
     }
 
     fn to_last(&mut self) {
-        self.next_idx = self.entries.len() as i64 - 1;
-        self.update_key();
+        if !self.entries.is_empty() {
+            self.next_idx = self.entries.len() - 1;
+            self.update_key();
+        }
     }
 }
 
@@ -620,7 +630,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pending_writes_iterator() {
+    fn test_pending_writes_iterator() {
         let n = 100;
 
         let mut entries = Vec::new();
@@ -693,6 +703,73 @@ mod tests {
                 assert_eq!(user_key(pending_writes.key()), key(n - 1).to_vec());
             } else {
                 assert_eq!(user_key(pending_writes.key()), key(0).to_vec());
+            }
+        };
+
+        check(0, false, entries.clone());
+
+        entries.reverse();
+
+        check(0, true, entries.clone());
+    }
+
+    #[test]
+    fn test_pending_writes_iterator_out_of_bound() {
+        let n = 100;
+
+        let mut entries = Vec::new();
+
+        let key = |i| BytesMut::from(format!("key-{:012x}", i).as_bytes());
+        let value = |i| Bytes::from(format!("value-{:012x}", i));
+
+        for i in 0..n {
+            let entry = Entry::new(key(i).freeze(), value(i));
+            entries.push(entry);
+        }
+
+        let check = |read_ts: u64, reversed: bool, entries: Vec<Entry>| {
+            let mut iter = PendingWritesIterator::new(read_ts, reversed, entries);
+
+            iter.rewind();
+            iter.prev();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(iter.valid());
+
+            iter.prev();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(iter.valid());
+
+            if !reversed {
+                assert_eq!(user_key(iter.key()), key(0).to_vec());
+            } else {
+                assert_eq!(user_key(iter.key()), key(n - 1).to_vec());
+            }
+
+            iter.to_last();
+            iter.next();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(iter.valid());
+
+            iter.next();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(iter.valid());
+
+            if !reversed {
+                assert_eq!(user_key(iter.key()), key(n - 1).to_vec());
+            } else {
+                assert_eq!(user_key(iter.key()), key(0).to_vec());
             }
         };
 

--- a/src/table/concat_iterator.rs
+++ b/src/table/concat_iterator.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// ConcatIterator iterates on SSTs with no overlap keys.
 pub struct ConcatIterator {
-    cur: Option<usize>,
+    cur: usize,
     iters: Vec<Option<TableIterator>>,
     tables: Vec<Table>,
     opt: usize,
@@ -21,7 +21,7 @@ impl ConcatIterator {
         let iters = tables.iter().map(|_| None).collect();
 
         ConcatIterator {
-            cur: None,
+            cur: 0,
             iters,
             tables,
             opt,
@@ -29,48 +29,64 @@ impl ConcatIterator {
     }
 
     fn set_idx(&mut self, idx: usize) {
-        if idx >= self.iters.len() {
-            self.cur = None;
+        assert!(idx == std::usize::MAX || idx <= self.tables.len());
+        self.cur = idx;
+
+        if idx == std::usize::MAX || idx == self.iters.len() {
             return;
         }
+
         if self.iters[idx].is_none() {
             self.iters[idx] = Some(self.tables[idx].new_iterator(self.opt));
         }
-        self.cur = Some(idx);
     }
 
     fn iter_mut(&mut self) -> &mut TableIterator {
-        self.iters[self.cur.unwrap()].as_mut().unwrap()
+        self.iters[self.cur].as_mut().unwrap()
     }
 
     fn iter_ref(&self) -> &TableIterator {
-        self.iters[self.cur.unwrap()].as_ref().unwrap()
+        self.iters[self.cur].as_ref().unwrap()
     }
 }
 
 impl AgateIterator for ConcatIterator {
     fn next(&mut self) {
-        let cur = self.cur.unwrap();
-        let cur_iter = self.iter_mut();
-        cur_iter.next();
-        if cur_iter.valid() {
-            return;
+        if self.cur != std::usize::MAX && self.cur < self.iters.len() {
+            let cur_iter = self.iter_mut();
+            cur_iter.next();
+            if cur_iter.valid() {
+                return;
+            }
         }
+
         loop {
             if self.opt & ITERATOR_REVERSED == 0 {
-                self.set_idx(cur + 1);
-            } else if cur == 0 {
-                self.cur = None;
-            } else {
-                self.set_idx(cur - 1);
-            }
+                if self.cur == std::usize::MAX {
+                    self.rewind();
+                    return;
+                } else if self.cur < self.iters.len() {
+                    self.set_idx(self.cur + 1);
 
-            if self.cur.is_some() {
-                self.iter_mut().rewind();
-                if self.iter_ref().valid() {
+                    if self.cur == self.iters.len() {
+                        return;
+                    }
+                } else {
                     return;
                 }
             } else {
+                if self.cur == std::usize::MAX {
+                    return;
+                } else if self.cur > 0 {
+                    self.set_idx(self.cur - 1);
+                } else {
+                    self.set_idx(std::usize::MAX);
+                    return;
+                }
+            }
+
+            self.iter_mut().rewind();
+            if self.iter_ref().valid() {
                 return;
             }
         }
@@ -96,8 +112,8 @@ impl AgateIterator for ConcatIterator {
             idx = crate::util::search(self.tables.len(), |idx| {
                 COMPARATOR.compare_key(self.tables[idx].biggest(), key) != Less
             });
+            self.set_idx(idx);
             if idx >= self.tables.len() {
-                self.cur = None;
                 return;
             }
         } else {
@@ -105,8 +121,8 @@ impl AgateIterator for ConcatIterator {
             let ridx = crate::util::search(self.tables.len(), |idx| {
                 COMPARATOR.compare_key(self.tables[n - 1 - idx].smallest(), key) != Greater
             });
+            self.set_idx(ridx);
             if ridx >= self.tables.len() {
-                self.cur = None;
                 return;
             }
             idx = n - 1 - ridx;
@@ -125,7 +141,7 @@ impl AgateIterator for ConcatIterator {
     }
 
     fn valid(&self) -> bool {
-        if self.cur.is_some() {
+        if self.cur != std::usize::MAX && self.cur < self.iters.len() {
             self.iter_ref().valid()
         } else {
             false
@@ -133,30 +149,41 @@ impl AgateIterator for ConcatIterator {
     }
 
     fn prev(&mut self) {
-        let cur = self.cur.unwrap();
-        let cur_iter = self.iter_mut();
-        cur_iter.prev();
-        if cur_iter.valid() {
-            return;
+        if self.cur != std::usize::MAX && self.cur < self.iters.len() {
+            let cur_iter = self.iter_mut();
+            cur_iter.prev();
+            if cur_iter.valid() {
+                return;
+            }
         }
 
         loop {
             if self.opt & ITERATOR_REVERSED == 0 {
-                if cur == 0 {
-                    self.cur = None
+                if self.cur == std::usize::MAX {
+                    return;
+                } else if self.cur > 0 {
+                    self.set_idx(self.cur - 1);
                 } else {
-                    self.set_idx(cur - 1);
-                }
-            } else {
-                self.set_idx(cur + 1);
-            }
-
-            if self.cur.is_some() {
-                self.iter_mut().to_last();
-                if self.iter_ref().valid() {
+                    self.set_idx(std::usize::MAX);
                     return;
                 }
             } else {
+                if self.cur == std::usize::MAX {
+                    self.to_last();
+                    return;
+                } else if self.cur < self.iters.len() {
+                    self.set_idx(self.cur + 1);
+
+                    if self.cur == self.iters.len() {
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            }
+
+            self.iter_mut().to_last();
+            if self.iter_ref().valid() {
                 return;
             }
         }
@@ -283,5 +310,61 @@ mod tests {
         check(tables.clone(), false);
 
         check(tables, true);
+    }
+
+    #[test]
+    fn test_concat_iterator_out_of_bound() {
+        let (tables, cnt) = build_test_tables();
+
+        let check = |tables: Vec<Table>, reversed: bool| {
+            let opt = if reversed { ITERATOR_REVERSED } else { 0 };
+            let mut iter = ConcatIterator::from_tables(tables, opt);
+
+            iter.rewind();
+            iter.prev();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(iter.valid());
+
+            iter.prev();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(iter.valid());
+
+            if !reversed {
+                assert_eq!(user_key(iter.key()), format!("{:012x}", 0).as_bytes());
+            } else {
+                assert_eq!(user_key(iter.key()), format!("{:012x}", cnt - 1).as_bytes());
+            }
+
+            iter.to_last();
+            iter.next();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(iter.valid());
+
+            iter.next();
+            assert!(!iter.valid());
+            iter.next();
+            assert!(!iter.valid());
+            iter.prev();
+            assert!(iter.valid());
+
+            if !reversed {
+                assert_eq!(user_key(iter.key()), format!("{:012x}", cnt - 1).as_bytes());
+            } else {
+                assert_eq!(user_key(iter.key()), format!("{:012x}", 0).as_bytes());
+            }
+        };
+
+        check(tables.clone(), false);
+
+        check(tables.clone(), true);
     }
 }

--- a/src/table/concat_iterator.rs
+++ b/src/table/concat_iterator.rs
@@ -60,6 +60,7 @@ impl AgateIterator for ConcatIterator {
             }
         }
 
+        #[allow(clippy::collapsible_else_if)]
         loop {
             if self.opt & ITERATOR_REVERSED == 0 {
                 if self.cur == std::usize::MAX {
@@ -157,6 +158,7 @@ impl AgateIterator for ConcatIterator {
             }
         }
 
+        #[allow(clippy::collapsible_else_if)]
         loop {
             if self.opt & ITERATOR_REVERSED == 0 {
                 if self.cur == std::usize::MAX {
@@ -365,6 +367,6 @@ mod tests {
 
         check(tables.clone(), false);
 
-        check(tables.clone(), true);
+        check(tables, true);
     }
 }

--- a/src/table/merge_iterator.rs
+++ b/src/table/merge_iterator.rs
@@ -245,7 +245,9 @@ impl AgateIterator for MergeIterator {
     fn prev(&mut self) {
         // TODO: Re-examine this.
 
+        // TODO: Avoid calling prev when iterator is invalid.
         self.bigger_mut().prev();
+
         if !self.bigger().valid {
             // Prev element is in the smaller.
             self.smaller_mut().prev();
@@ -349,7 +351,7 @@ mod tests {
         }
     }
 
-    fn gen_vec_data(n: usize, predicate: impl Fn(usize) -> bool) -> Vec<Bytes> {
+    pub fn gen_vec_data(n: usize, predicate: impl Fn(usize) -> bool) -> Vec<Bytes> {
         (0..n)
             .filter(|x| predicate(*x))
             .map(|i| key_with_ts(format!("{:012x}", i).as_str(), 0))

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -456,14 +456,45 @@ fn test_iterator_out_of_bound() {
     let opts = get_test_table_options();
     let table = build_test_table(b"key", 1000, opts);
     let mut it = table.new_iterator(0);
+    // next first and then prev
     it.seek_to_last();
     assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
+    it.rewind();
+    assert!(it.error().is_none());
+
+    // prev first and then next
+    it.seek_to_first();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
     it.rewind();
     assert!(it.error().is_none());
     assert_eq!(user_key(it.key()), key(b"key", 0));
@@ -474,14 +505,45 @@ fn test_iterator_out_of_bound_reverse() {
     let opts = get_test_table_options();
     let table = build_test_table(b"key", 1000, opts);
     let mut it = table.new_iterator(ITERATOR_REVERSED);
+    // next first and then prev
     it.seek_to_first();
     assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
+    it.rewind();
+    assert!(it.error().is_none());
+
+    // prev first and then next
+    it.seek_to_last();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
     it.rewind();
     assert!(it.error().is_none());
     assert_eq!(user_key(it.key()), key(b"key", 999));


### PR DESCRIPTION
Signed-off-by: GanZiheng <ganziheng98@gmail.com>

Uniform all kinds of iterators which implement the `AgateIterator` trait.

Suppose we have another two extra elements in the data which the iterator iterates over, one is before the original first element, called `before first`, and another is after the last original element, namely `after last`.

1. If we arrives the first element, and call `prev`, we will arrive `before first`, and `valid` will return false;
2. If we arrives the last element, and call `next`, we will arrive `after last`, and `valid` will return false;
3. At `before first`, if  we call `prev`, nothing will change, and if we call `next`, we will move to the first element;
4. At `after last`, if  we call `next`, nothing will change, and if we call `prev`, we will move to the last element;